### PR TITLE
:arrow_up: Maintain allKeys to be readable

### DIFF
--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/DiskCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/DiskCache.kt
@@ -2,23 +2,34 @@ package com.github.kittinunf.fuse.core.cache
 
 import com.jakewharton.disklrucache.DiskLruCache
 import java.io.File
+import java.nio.charset.Charset
 
 internal class DiskCache private constructor(private val cache: DiskLruCache) :
     Persistence<ByteArray> {
+
+    enum class OutputStreamIndex {
+        Data, Key
+    }
 
     companion object {
         const val JOURNAL_FILE = "journal"
 
         fun open(cacheDir: String, uniqueName: String, capacity: Long): DiskCache {
             val f = File(cacheDir)
-            val disk = DiskLruCache.open(f.resolve(uniqueName), 1, 1, capacity)
+            val disk = DiskLruCache.open(
+                f.resolve(uniqueName),
+                1,
+                OutputStreamIndex.values().size,
+                capacity
+            )
             return DiskCache(disk)
         }
     }
 
-    override fun put(key: String, value: ByteArray) {
-        cache.edit(key).apply {
+    override fun put(safeKey: String, key: String, value: ByteArray) {
+        cache.edit(safeKey).apply {
             newOutputStream(0).use { it.write(value) }
+            newOutputStream(1).use { it.write(key.toByteArray()) }
             commit()
         }
     }
@@ -29,26 +40,34 @@ internal class DiskCache private constructor(private val cache: DiskLruCache) :
         cache.delete()
     }
 
-    override fun allKeys(): List<String> {
-        return synchronized(this) {
-            cache.directory.listFiles().filter { it.isFile && it.name == JOURNAL_FILE }
-                .map { it.name }
-        }
+    override fun allKeys(): Set<String> {
+        return allSafeKeys()
+            .map {
+                get(it, OutputStreamIndex.Key.ordinal)!!.toString(Charset.defaultCharset())
+            }
+            .toSet()
+    }
+
+    private fun allSafeKeys() = synchronized(this) {
+        cache.directory.listFiles().filter { it.isFile && it.name != JOURNAL_FILE }
+            .map { it.name.substringBefore(".") }
     }
 
     override fun size(): Long = cache.size()
 
-    override fun get(key: String): ByteArray? {
+    override fun get(key: String): ByteArray? = get(key, OutputStreamIndex.Data.ordinal)
+
+    private fun get(key: String, indexStream: Int): ByteArray? {
         val snapshot = cache.get(key)
         return snapshot?.let {
-            it.getInputStream(0).use { it.readBytes() }
+            it.getInputStream(indexStream).use { it.readBytes() }
         }
     }
 
-    fun setIfMissing(key: String, value: ByteArray) {
-        val fetched = get(key)
+    fun setIfMissing(safeKey: String, key: String, value: ByteArray) {
+        val fetched = get(safeKey)
         if (fetched == null) {
-            put(key, value)
+            put(safeKey, key, value)
         }
     }
 }

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
@@ -4,10 +4,11 @@ interface Persistence<T> {
     /**
      * Save the data supplied based on a certain mechanism which provides persistence somehow
      *
-     * @param key The key associated with the value to be persisted
+     * @param safeKey The safeKey associated with the value to be persisted, this is sanitized key and it is conformed to regex <strong>[a-z0-9_-]{1,64}</strong>
+     * @param key The key associated with the value to be persisted, this is an un-sanitized key which is the same as the call-site key
      * @param value The value to be persisted
      */
-    fun put(key: String, value: T)
+    fun put(safeKey: String, key: String, value: T)
 
     /**
      * Remove the data associated with its particular key
@@ -22,9 +23,9 @@ interface Persistence<T> {
     fun removeAll()
 
     /**
-     * Retrieve the keys from all values persisted
+     * Retrieve the keys from all values persisted, internally
      */
-    fun allKeys(): List<String>
+    fun allKeys(): Set<String>
 
     /**
      * Retrieve accumulated values

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
@@ -23,7 +23,7 @@ interface Persistence<T> {
     fun removeAll()
 
     /**
-     * Retrieve the keys from all values persisted, internally
+     * Retrieve the keys from all values persisted, this is a <string>real</strong> as opposed to safeKey
      */
     fun allKeys(): Set<String>
 

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/fetch/DiskFetcher.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/fetch/DiskFetcher.kt
@@ -13,15 +13,13 @@ class DiskFetcher<T : Any>(val file: File, private val convertible: Fuse.DataCon
     private var cancelled: Boolean = false
 
     override fun fetch(handler: (Result<T, Exception>) -> Unit) {
-        cancelled = false
+        if (cancelled) {
+            return
+        }
 
         var bytes = ByteArray(0)
 
         var hasFailed = false
-
-        if (cancelled) {
-            return
-        }
 
         try {
             bytes = file.readBytes()
@@ -33,6 +31,7 @@ class DiskFetcher<T : Any>(val file: File, private val convertible: Fuse.DataCon
         if (cancelled or hasFailed) {
             return
         }
+
         handler(Result.of(convertFromData(bytes)))
     }
 

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -28,8 +28,9 @@ class FuseByteCacheTest : BaseTestCase() {
     companion object {
         private val tempDir = createTempDir().absolutePath
         val cache =
-            CacheBuilder.config<ByteArray>(tempDir) { callbackExecutor = Executor { it.run() } }
-                .build(ByteArrayDataConvertible())
+            CacheBuilder.config<ByteArray>(tempDir, "Byte") {
+                callbackExecutor = Executor { it.run() }
+            }.build(ByteArrayDataConvertible())
     }
 
     private var hasSetUp = false


### PR DESCRIPTION
### What's in this PR?

This PR implements mechanism internally to make sure that `allKeys()` is returning user-understandable keys.

### Usage

```kotlin
(1..10).forEach {
  cache.get("$it", { "value" } { value, type -> })
}
```

```kotlin

cache = ... // instantiate
cache.allKeys() // this would return 1,2,3...10
```

