### PR TITLE
:bug: [Core] Exposing put for client to use

### DIFF
--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
@@ -94,7 +94,11 @@ class Cache<T : Any> internal constructor(
             val bytes = diskCache.get(safeKey)
             if (bytes == null) {
                 // not found we need to fetch then put it back
-                fetchAndPut(fetcher, fetchHandler)
+                fetchAndPut(fetcher) { result ->
+                    thread(config.callbackExecutor) {
+                        fetchHandler?.invoke(result)
+                    }
+                }
             } else {
                 // found in disk, save back into mem
                 val result = Result.of<T, Exception> {

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Convertibles.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Convertibles.kt
@@ -1,7 +1,6 @@
 package com.github.kittinunf.fuse.core
 
 import java.nio.charset.Charset
-import org.json.JSONObject
 
 class ByteArrayDataConvertible : Fuse.DataConvertible<ByteArray> {
     override fun convertFromData(bytes: ByteArray): ByteArray = bytes
@@ -11,9 +10,4 @@ class ByteArrayDataConvertible : Fuse.DataConvertible<ByteArray> {
 class StringDataConvertible(private val charset: Charset = Charset.defaultCharset()) : Fuse.DataConvertible<String> {
     override fun convertFromData(bytes: ByteArray): String = bytes.toString(charset)
     override fun convertToData(value: String): ByteArray = value.toByteArray(charset)
-}
-
-class JsonDataConvertible(private val charset: Charset = Charset.defaultCharset()) : Fuse.DataConvertible<JSONObject> {
-    override fun convertFromData(bytes: ByteArray): JSONObject = JSONObject(bytes.toString(charset))
-    override fun convertToData(value: JSONObject): ByteArray = value.toString().toByteArray(charset)
 }

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/fetch/Fetcher.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/fetch/Fetcher.kt
@@ -47,3 +47,12 @@ fun <T : Any> Cache<T>.get(
     val fetcher = if (getValue == null) NoFetcher<T>(key) else SimpleFetcher(key, getValue)
     get(fetcher, handler)
 }
+
+fun <T : Any> Cache<T>.put(
+    key: String,
+    putValue: T? = null,
+    handler: ((Result<T, Exception>) -> Unit)? = null
+) {
+    val fetcher = if (putValue == null) NoFetcher<T>(key) else SimpleFetcher(key, { putValue })
+    put(fetcher, handler)
+}

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -6,6 +6,7 @@ import com.github.kittinunf.fuse.core.CacheBuilder
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.NotFoundException
 import com.github.kittinunf.fuse.core.fetch.get
+import com.github.kittinunf.fuse.core.fetch.put
 import java.nio.charset.Charset
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseJsonCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseJsonCacheTest.kt
@@ -1,23 +1,35 @@
 package com.github.kittinunf.fuse
 
 import com.github.kittinunf.fuse.core.CacheBuilder
-import com.github.kittinunf.fuse.core.JsonDataConvertible
+import com.github.kittinunf.fuse.core.Fuse
 import com.github.kittinunf.fuse.core.build
+import com.github.kittinunf.fuse.core.fetch.DiskFetcher
 import com.github.kittinunf.fuse.core.fetch.get
 import java.io.FileNotFoundException
 import java.net.URL
+import java.nio.charset.Charset
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.CoreMatchers.isA
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Test
 
 class FuseJsonCacheTest : BaseTestCase() {
+
+    class JsonDataConvertible(private val charset: Charset = Charset.defaultCharset()) :
+        Fuse.DataConvertible<JSONObject> {
+        override fun convertFromData(bytes: ByteArray): JSONObject =
+            JSONObject(bytes.toString(charset))
+
+        override fun convertToData(value: JSONObject): ByteArray =
+            value.toString().toByteArray(charset)
+    }
 
     companion object {
         private val tempDir = createTempDir().absolutePath
@@ -117,5 +129,28 @@ class FuseJsonCacheTest : BaseTestCase() {
 
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
+        assertThat(error as? JSONException, isA(JSONException::class.java))
+    }
+
+    @Test
+    fun putWithValueJsonNotCompatible() {
+        val lock = CountDownLatch(1)
+
+        var value: JSONObject? = null
+        var error: Exception? = null
+
+        val json = assetDir.resolve("broken_json.json")
+
+        cache.put(DiskFetcher(json, cache)) { result ->
+            val (v, e) = result
+            value = v
+            error = e
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, nullValue())
+        assertThat(error, notNullValue())
+        assertThat(error as? JSONException, isA(JSONException::class.java))
     }
 }


### PR DESCRIPTION
### What's in this PR?

This PR exposes `put` for the client to use. This is a long-overdue request that I have never updated the library! It is time to do it now.

### Usage

```kotlin
cache = // instantiation for Cache<String>

cache.put("Test Put", "Hello world") { (value, err) ->
  println(value)  //this should return "hello world"
}

//also support put with fetcher
cache.put(SomeFetcher()) { (value, err) ->
  println(value) //this should return value coming down from fetcher
}
```
