### PR TITLE
⌛️ [Feature] Introducing Expirable Cache Scenario

### DIFF
--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
@@ -146,15 +146,21 @@ class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.
         }
     }
 
-    override fun remove(key: String, removeOnlyInMemory: Boolean) {
+    override fun remove(key: String, fromSource: Source) {
+        require(fromSource != Source.ORIGIN) { "Cannot remove from Source.ORIGIN" }
+
         val safeKey = key.md5()
-        memCache.remove(safeKey)
-        if (!removeOnlyInMemory) diskCache.remove(safeKey)
+        when (fromSource) {
+            Source.MEM -> memCache.remove(safeKey)
+            Source.DISK -> diskCache.remove(safeKey)
+            else -> {
+            }
+        }
     }
 
-    override fun removeAll(removeOnlyInMemory: Boolean) {
+    override fun removeAll() {
         memCache.removeAll()
-        if (!removeOnlyInMemory) diskCache.removeAll()
+        diskCache.removeAll()
     }
 
     override fun allKeys(): Set<String> {

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
@@ -31,11 +31,11 @@ object CacheBuilder {
 
 fun <T : Any> Config<T>.build() = Cache(this)
 
-class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.Cacheable<T>,
-    Fuse.DataConvertible<T> by config.convertible {
+class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.Cacheable,
+    Fuse.Cacheable.Put<T>, Fuse.Cacheable.Get<T>, Fuse.DataConvertible<T> by config.convertible {
 
     enum class Source {
-        NOT_FOUND,
+        ORIGIN,
         MEM,
         DISK,
     }
@@ -49,11 +49,11 @@ class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.
         )
     }
 
-    override fun put(fetcher: Fetcher<T>, success: ((Result<T, Exception>) -> Unit)?) {
+    override fun put(fetcher: Fetcher<T>, handler: ((Result<T, Exception>) -> Unit)?) {
         dispatch(config.dispatchedExecutor) {
             fetchAndPut(fetcher) { result ->
                 thread(config.callbackExecutor) {
-                    success?.invoke(result)
+                    handler?.invoke(result)
                 }
             }
         }
@@ -67,7 +67,7 @@ class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.
         get(fetcher,
             { handler?.invoke(it, Source.MEM) },
             { handler?.invoke(it, Source.DISK) },
-            { handler?.invoke(it, Source.NOT_FOUND) })
+            { handler?.invoke(it, Source.ORIGIN) })
     }
 
     private fun get(

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
@@ -146,14 +146,15 @@ class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.
         }
     }
 
-    override fun remove(key: String, fromSource: Source) {
+    override fun remove(key: String, fromSource: Source): Boolean {
         require(fromSource != Source.ORIGIN) { "Cannot remove from Source.ORIGIN" }
 
         val safeKey = key.md5()
-        when (fromSource) {
+        return when (fromSource) {
             Source.MEM -> memCache.remove(safeKey)
             Source.DISK -> diskCache.remove(safeKey)
             else -> {
+                false
             }
         }
     }

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
@@ -27,9 +27,9 @@ class Fuse {
             )
         }
 
-        fun remove(key: String, removeOnlyInMemory: Boolean = false)
+        fun remove(key: String, fromSource: Cache.Source = Cache.Source.MEM)
 
-        fun removeAll(removeOnlyInMemory: Boolean = false)
+        fun removeAll()
 
         fun allKeys(): Set<String>
 

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
@@ -14,25 +14,68 @@ class Fuse {
 
         interface Put<T : Any> {
 
+            /**
+             *  Put the entry supplied by fetcher into the persistence.
+             *  This method will automatically fetch the value from the fetcher and put the entry into the cache (both Memory, and Disk).
+             *
+             * @param fetcher The key associated with the object to be persisted
+             * @param handler The handler block to be called whenever the operation is completed
+             */
             fun put(fetcher: Fetcher<T>, handler: ((Result<T, Exception>) -> Unit)? = null)
         }
 
         interface Get<T : Any> {
 
+            /**
+             *  Get the entry associated with its particular key which provided by the persistence.
+             *  This method will automatically fetch if and only if the entry was not already saved in the persistence previously
+             *  Otherwise it will return the entry from the persistence
+             *
+             * @param fetcher The key associated with the object to be persisted
+             * @param handler The handler block to be called whenever the operation is completed
+             */
             fun get(fetcher: Fetcher<T>, handler: ((Result<T, Exception>) -> Unit)? = null)
 
+            /**
+             *  Get the entry associated with its particular key which provided by the persistence.
+             *  This method will automatically fetch if and only if the entry was not already saved in the persistence previously
+             *  Otherwise it will return the entry from the persistence which specified by Source (ORIGIN, MEM, or DISK)
+             *
+             * @param fetcher The key associated with the object to be persisted
+             * @param handler The handler block to be called whenever the operation is completed
+             */
             fun get(
                 fetcher: Fetcher<T>,
                 handler: ((Result<T, Exception>, Cache.Source) -> Unit)? = null
             )
         }
 
-        fun remove(key: String, fromSource: Cache.Source = Cache.Source.MEM)
+        /**
+         *  Remove the entry associated with its particular key which was saved previously
+         *  In the case of, entry is not found, it will no-op and return false
+         *
+         * @param key The key associated with the object to be persisted
+         * @param fromSource The source of the value to be removed, either MEM or DISK
+         * @return Boolean Whether the value was removed successfully
+         */
+        fun remove(key: String, fromSource: Cache.Source = Cache.Source.MEM): Boolean
 
+        /**
+         *  Remove all the entry in the persistence
+         */
         fun removeAll()
 
+        /**
+         *  Retrieve the keys from all values persisted
+         * @return Set<String> Set of keys
+         */
         fun allKeys(): Set<String>
 
+        /**
+         *  Retrieve the keys from all values persisted
+         * @param key The key associated with the object to be persisted
+         * @return Long represents the timestamp in milliseconds since epoch 1970
+         */
         fun getTimestamp(key: String): Long
     }
 }

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
@@ -10,16 +10,22 @@ class Fuse {
         fun convertToData(value: T): ByteArray
     }
 
-    interface Cacheable<T : Any> {
+    interface Cacheable {
 
-        fun put(fetcher: Fetcher<T>, success: ((Result<T, Exception>) -> Unit)? = null)
+        interface Put<T : Any> {
 
-        fun get(fetcher: Fetcher<T>, handler: ((Result<T, Exception>) -> Unit)? = null)
+            fun put(fetcher: Fetcher<T>, handler: ((Result<T, Exception>) -> Unit)? = null)
+        }
 
-        fun get(
-            fetcher: Fetcher<T>,
-            handler: ((Result<T, Exception>, Cache.Source) -> Unit)? = null
-        )
+        interface Get<T : Any> {
+
+            fun get(fetcher: Fetcher<T>, handler: ((Result<T, Exception>) -> Unit)? = null)
+
+            fun get(
+                fetcher: Fetcher<T>,
+                handler: ((Result<T, Exception>, Cache.Source) -> Unit)? = null
+            )
+        }
 
         fun remove(key: String, removeOnlyInMemory: Boolean = false)
 

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
@@ -2,7 +2,7 @@ package com.github.kittinunf.fuse.core.cache
 
 internal interface Persistence<T> {
     /**
-     * Save the entry supplied based on a certain mechanism which provides persistence somehow
+     * Save the entry supplied based on a certain mechanism which provides persistence
      *
      * @param safeKey The safeKey associated with the value to be persisted, this is sanitized key and it is conformed to regex <strong>[a-z0-9_-]{1,64}</strong>
      * @param key The key associated with the value to be persisted, this is an un-sanitized key which is the same as the call-site key
@@ -20,7 +20,7 @@ internal interface Persistence<T> {
     fun remove(key: String): Boolean
 
     /**
-     * Remove all the entry
+     * Remove all the entry in the persistence
      */
     fun removeAll()
 

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
@@ -2,7 +2,7 @@ package com.github.kittinunf.fuse.core.cache
 
 internal interface Persistence<T> {
     /**
-     * Save the data supplied based on a certain mechanism which provides persistence somehow
+     * Save the entry supplied based on a certain mechanism which provides persistence somehow
      *
      * @param safeKey The safeKey associated with the value to be persisted, this is sanitized key and it is conformed to regex <strong>[a-z0-9_-]{1,64}</strong>
      * @param key The key associated with the value to be persisted, this is an un-sanitized key which is the same as the call-site key
@@ -12,7 +12,7 @@ internal interface Persistence<T> {
     fun put(safeKey: String, key: String, value: T, timeToPersist: Long)
 
     /**
-     * Remove the data associated with its particular key
+     * Remove the entry associated with its particular key
      *
      * @param key The key associated with the object to be deleted from persistence
      * @return Boolean Whether the key was removed successfully
@@ -20,7 +20,7 @@ internal interface Persistence<T> {
     fun remove(key: String): Boolean
 
     /**
-     * Remove all the data
+     * Remove all the entry
      */
     fun removeAll()
 
@@ -44,7 +44,7 @@ internal interface Persistence<T> {
     fun get(key: String): T?
 
     /**
-     * Get timestamp associated with its particular key
+     * Get timestamp in milliseconds associated with its particular key
      *
      * @param key The key associated with the value to be retrieved from persistence
      */

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
@@ -10,10 +10,10 @@ import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
-@ExperimentalTime
 class ExpirableCache<T : Any>(private val cache: Cache<T>) : Fuse.Cacheable by cache,
     Fuse.Cacheable.Put<T> by cache {
 
+    @ExperimentalTime
     fun get(
         fetcher: Fetcher<T>,
         timeLimit: Duration = Duration.INFINITE,
@@ -23,6 +23,7 @@ class ExpirableCache<T : Any>(private val cache: Cache<T>) : Fuse.Cacheable by c
         get(fetcher, timeLimit, useEntryEvenIfExpired) { result, _ -> handler?.invoke(result) }
     }
 
+    @ExperimentalTime
     fun get(
         fetcher: Fetcher<T>,
         timeLimit: Duration = Duration.INFINITE,
@@ -47,6 +48,7 @@ class ExpirableCache<T : Any>(private val cache: Cache<T>) : Fuse.Cacheable by c
         }
     }
 
+    @ExperimentalTime
     private fun hasExpired(persistedTimestamp: Long, timeLimit: Duration): Boolean {
         val now = System.currentTimeMillis()
         val durationSincePersisted = (now - persistedTimestamp).milliseconds
@@ -87,4 +89,3 @@ fun <T : Any> ExpirableCache<T>.put(
     val fetcher = if (putValue == null) NoFetcher<T>(key) else SimpleFetcher(key, { putValue })
     put(fetcher, handler)
 }
-

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
@@ -1,0 +1,90 @@
+package com.github.kittinunf.fuse.core.scenario
+
+import com.github.kittinunf.fuse.core.Cache
+import com.github.kittinunf.fuse.core.Fuse
+import com.github.kittinunf.fuse.core.fetch.Fetcher
+import com.github.kittinunf.fuse.core.fetch.NoFetcher
+import com.github.kittinunf.fuse.core.fetch.SimpleFetcher
+import com.github.kittinunf.result.Result
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+
+@ExperimentalTime
+class ExpirableCache<T : Any>(private val cache: Cache<T>) : Fuse.Cacheable by cache,
+    Fuse.Cacheable.Put<T> by cache {
+
+    fun get(
+        fetcher: Fetcher<T>,
+        timeLimit: Duration = Duration.INFINITE,
+        useEntryEvenIfExpired: Boolean = false,
+        handler: ((Result<T, Exception>) -> Unit)? = null
+    ) {
+        get(fetcher, timeLimit, useEntryEvenIfExpired) { result, _ -> handler?.invoke(result) }
+    }
+
+    fun get(
+        fetcher: Fetcher<T>,
+        timeLimit: Duration = Duration.INFINITE,
+        useEntryEvenIfExpired: Boolean = false,
+        handler: ((Result<T, Exception>, Cache.Source) -> Unit)? = null
+    ) {
+        val key = fetcher.key
+        val persistedTimestamp = getTimestamp(key)
+
+        // no timestamp fetch
+        if (persistedTimestamp == -1L) {
+            put(fetcher) { handler?.invoke(it, Cache.Source.ORIGIN) }
+        } else {
+            val isExpired = hasExpired(persistedTimestamp, timeLimit)
+
+            // if it is not expired yet, user wants to use it even it is already expired
+            if (!isExpired || useEntryEvenIfExpired) {
+                cache.get(fetcher, handler)
+            } else {
+                put(fetcher) { handler?.invoke(it, Cache.Source.ORIGIN) }
+            }
+        }
+    }
+
+    private fun hasExpired(persistedTimestamp: Long, timeLimit: Duration): Boolean {
+        val now = System.currentTimeMillis()
+        val durationSincePersisted = (now - persistedTimestamp).milliseconds
+        return durationSincePersisted > timeLimit
+    }
+}
+
+@ExperimentalTime
+fun <T : Any> ExpirableCache<T>.get(
+    key: String,
+    getValue: (() -> T?)? = null,
+    timeLimit: Duration = Duration.INFINITE,
+    useEntryEvenIfExpired: Boolean = false,
+    handler: ((Result<T, Exception>) -> Unit)? = null
+) {
+    val fetcher = if (getValue == null) NoFetcher<T>(key) else SimpleFetcher(key, getValue)
+    get(fetcher, timeLimit, useEntryEvenIfExpired, handler)
+}
+
+@ExperimentalTime
+fun <T : Any> ExpirableCache<T>.get(
+    key: String,
+    getValue: (() -> T?)? = null,
+    timeLimit: Duration = Duration.INFINITE,
+    useEntryEvenIfExpired: Boolean = false,
+    handler: ((Result<T, Exception>, Cache.Source) -> Unit)? = null
+) {
+    val fetcher = if (getValue == null) NoFetcher<T>(key) else SimpleFetcher(key, getValue)
+    get(fetcher, timeLimit, useEntryEvenIfExpired, handler)
+}
+
+@ExperimentalTime
+fun <T : Any> ExpirableCache<T>.put(
+    key: String,
+    putValue: T? = null,
+    handler: ((Result<T, Exception>) -> Unit)? = null
+) {
+    val fetcher = if (putValue == null) NoFetcher<T>(key) else SimpleFetcher(key, { putValue })
+    put(fetcher, handler)
+}
+

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
@@ -43,6 +43,7 @@ class ExpirableCache<T : Any>(private val cache: Cache<T>) : Fuse.Cacheable by c
             if (!isExpired || useEntryEvenIfExpired) {
                 cache.get(fetcher, handler)
             } else {
+                // fetch the value from the fetcher and put back
                 put(fetcher) { handler?.invoke(it, Cache.Source.ORIGIN) }
             }
         }

--- a/fuse/src/test/java/com/github/kittinunf/fuse/BaseTestCase.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/BaseTestCase.kt
@@ -1,10 +1,10 @@
 package com.github.kittinunf.fuse
 
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 abstract class BaseTestCase {

--- a/fuse/src/test/java/com/github/kittinunf/fuse/BaseTestCase.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/BaseTestCase.kt
@@ -1,10 +1,10 @@
 package com.github.kittinunf.fuse
 
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 abstract class BaseTestCase {

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -7,6 +7,11 @@ import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.NotFoundException
 import com.github.kittinunf.fuse.core.fetch.get
 import com.github.kittinunf.fuse.core.fetch.put
+import java.nio.charset.Charset
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.CoreMatchers.isA
@@ -20,11 +25,6 @@ import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
-import java.nio.charset.Charset
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executor
-import java.util.concurrent.TimeUnit
-import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class FuseByteCacheTest : BaseTestCase() {

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -7,10 +7,6 @@ import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.NotFoundException
 import com.github.kittinunf.fuse.core.fetch.get
 import com.github.kittinunf.fuse.core.fetch.put
-import java.nio.charset.Charset
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executor
-import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.CoreMatchers.isA
@@ -24,6 +20,11 @@ import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
+import java.nio.charset.Charset
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import org.hamcrest.CoreMatchers.`is` as isEqualTo
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class FuseByteCacheTest : BaseTestCase() {
@@ -65,7 +66,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), isEqualTo("world"))
         assertThat(error, nullValue())
-        assertThat(cacheSource, isEqualTo(Cache.Source.NOT_FOUND))
+        assertThat(cacheSource, isEqualTo(Cache.Source.ORIGIN))
     }
 
     @Test
@@ -89,7 +90,7 @@ class FuseByteCacheTest : BaseTestCase() {
 
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
-        assertThat(cacheSource, isEqualTo(Cache.Source.NOT_FOUND))
+        assertThat(cacheSource, isEqualTo(Cache.Source.ORIGIN))
     }
 
     @Test
@@ -265,6 +266,7 @@ class FuseByteCacheTest : BaseTestCase() {
 
         val timestamp = cache.getTimestamp("timestamp")
 
+        TimeUnit.MINUTES
         assertThat(timestamp, not(isEqualTo(-1L)))
         assertThat(System.currentTimeMillis() - timestamp, greaterThan(2000L))
     }
@@ -290,7 +292,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), equalTo("yoyo"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.NOT_FOUND))
+        assertThat(source, equalTo(Cache.Source.ORIGIN))
 
         cache.remove("YOYO")
 

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -138,7 +138,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(error, nullValue())
 
         // remove from memory cache
-        cache.remove("hello", true)
+        cache.remove("hello", Cache.Source.MEM)
 
         lock = CountDownLatch(1)
         cache.get("hello", { "world".toByteArray() }) { result, type ->
@@ -294,7 +294,8 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(error, nullValue())
         assertThat(source, equalTo(Cache.Source.ORIGIN))
 
-        cache.remove("YOYO")
+        cache.remove("YOYO", Cache.Source.MEM)
+        cache.remove("YOYO", Cache.Source.DISK)
 
         value = null
         error = null

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -318,15 +318,15 @@ class FuseByteCacheTest : BaseTestCase() {
     fun removeFromMem() {
         val lock = CountDownLatch(1)
 
-        cache.put("timestamp", "test".toByteArray()) { _ ->
+        cache.put("remove", "test".toByteArray()) { _ ->
             lock.countDown()
         }
         lock.wait()
 
-        val result = cache.remove("timestamp")
+        val result = cache.remove("remove")
         assertThat(result, equalTo(true))
 
-        val anotherResult = cache.remove("timestamp")
+        val anotherResult = cache.remove("remove")
         assertThat(anotherResult, equalTo(false))
     }
 
@@ -334,20 +334,20 @@ class FuseByteCacheTest : BaseTestCase() {
     fun removeFromDisk() {
         val lock = CountDownLatch(1)
 
-        cache.put("timestamp", "test".toByteArray()) { _ ->
+        cache.put("remove", "test".toByteArray()) { result ->
             lock.countDown()
         }
         lock.wait()
 
-        val result = cache.remove("timestamp", Cache.Source.DISK)
+        val result = cache.remove("remove", Cache.Source.DISK)
         assertThat(result, equalTo(true))
 
-        val anotherResult = cache.remove("timestamp", Cache.Source.MEM)
+        val anotherResult = cache.remove("remove", Cache.Source.MEM)
         assertThat(anotherResult, equalTo(true))
     }
 
     @Test
-    fun removeAll() {
+    fun removeThemAll() {
         val count = 10
         val lock = CountDownLatch(count)
 
@@ -359,10 +359,12 @@ class FuseByteCacheTest : BaseTestCase() {
         lock.wait()
 
         assertThat(cache.allKeys(), not(empty()))
-        assertThat(
-            cache.allKeys(),
-            hasItems("remove 1", "remove 2", "remove 3", "remove 4", "remove 5")
-        )
+        (1..count).forEach {
+            assertThat(
+                cache.allKeys(),
+                hasItems("remove $it")
+            )
+        }
         cache.removeAll()
         assertThat(cache.allKeys(), empty())
     }

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
@@ -44,7 +44,8 @@ class FuseScenarioTest : BaseTestCase() {
     @Test
     fun fetchWhenNoData() {
         // remove first if it exists
-        expirableCache.remove("hello")
+        expirableCache.remove("hello", Cache.Source.MEM)
+        expirableCache.remove("hello", Cache.Source.DISK)
 
         val lock = CountDownLatch(1)
 
@@ -130,7 +131,12 @@ class FuseScenarioTest : BaseTestCase() {
         Thread.sleep(6000)
 
         lock = CountDownLatch(1)
-        expirableCache.get("expired", { "new world" }, timeLimit = 5.seconds, useEntryEvenIfExpired = true) { (v, e), type ->
+        expirableCache.get(
+            "expired",
+            { "new world" },
+            timeLimit = 5.seconds,
+            useEntryEvenIfExpired = true
+        ) { (v, e), type ->
             value = v
             error = e
             source = type
@@ -212,7 +218,7 @@ class FuseScenarioTest : BaseTestCase() {
         error = null
 
         Thread.sleep(1000)
-        expirableCache.remove("not expired", true)
+        expirableCache.remove("not expired", Cache.Source.MEM)
 
         lock = CountDownLatch(1)
         expirableCache.get("not expired", { "new world" }, 5.seconds) { (v, e), type ->

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
@@ -6,6 +6,10 @@ import com.github.kittinunf.fuse.core.StringDataConvertible
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.scenario.ExpirableCache
 import com.github.kittinunf.fuse.core.scenario.get
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.notNullValue
@@ -13,10 +17,6 @@ import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executor
-import kotlin.time.ExperimentalTime
-import kotlin.time.seconds
 
 class FuseScenarioTest : BaseTestCase() {
 

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
@@ -1,0 +1,232 @@
+package com.github.kittinunf.fuse
+
+import com.github.kittinunf.fuse.core.Cache
+import com.github.kittinunf.fuse.core.CacheBuilder
+import com.github.kittinunf.fuse.core.StringDataConvertible
+import com.github.kittinunf.fuse.core.build
+import com.github.kittinunf.fuse.core.scenario.ExpirableCache
+import com.github.kittinunf.fuse.core.scenario.get
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
+
+class FuseScenarioTest : BaseTestCase() {
+
+    @ExperimentalTime
+    companion object {
+        private val tempDir = createTempDir().absolutePath
+        private val cache =
+            CacheBuilder.config(tempDir, StringDataConvertible()) {
+                callbackExecutor = Executor { it.run() }
+            }.build()
+
+        private val expirableCache = ExpirableCache(cache)
+    }
+
+    private var hasSetUp = false
+
+    @Before
+    fun initialize() {
+        if (!hasSetUp) {
+            hasSetUp = true
+        }
+    }
+
+    @ExperimentalTime
+    @Test
+    fun fetchWhenNoData() {
+        // remove first if it exists
+        expirableCache.remove("hello")
+
+        val lock = CountDownLatch(1)
+
+        var value: String? = null
+        var error: Exception? = null
+        var source: Cache.Source? = null
+
+        expirableCache.get("hello", { "world" }) { (v, e), type ->
+            value = v
+            error = e
+            source = type
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(error, nullValue())
+        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(expirableCache.getTimestamp("hello"), not(equalTo(-1L)))
+    }
+
+    @ExperimentalTime
+    @Test
+    fun fetchWithTimeLimitExpired() {
+        var lock = CountDownLatch(1)
+
+        var value: String? = null
+        var error: Exception? = null
+        var source: Cache.Source? = null
+
+        expirableCache.get("hello", { "world" }) { (v, e) ->
+            value = v
+            error = e
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("world"))
+        assertThat(error, nullValue())
+
+        Thread.sleep(6000)
+
+        lock = CountDownLatch(1)
+        expirableCache.get("hello", { "new world" }, timeLimit = 5.seconds) { (v, e), type ->
+            value = v
+            error = e
+            source = type
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("new world"))
+        assertThat(error, nullValue())
+        assertThat(source, equalTo(Cache.Source.ORIGIN))
+    }
+
+    @ExperimentalTime
+    @Test
+    fun fetchWithTimeLimitExpiredButStillForceToUse() {
+        var lock = CountDownLatch(1)
+
+        var value: String? = null
+        var error: Exception? = null
+        var source: Cache.Source? = null
+
+        expirableCache.get("expired", { "world" }) { (v, e) ->
+            value = v
+            error = e
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("world"))
+        assertThat(error, nullValue())
+
+        Thread.sleep(6000)
+
+        lock = CountDownLatch(1)
+        expirableCache.get("expired", { "new world" }, timeLimit = 5.seconds, useEntryEvenIfExpired = true) { (v, e), type ->
+            value = v
+            error = e
+            source = type
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("world"))
+        assertThat(error, nullValue())
+        assertThat(source, equalTo(Cache.Source.MEM))
+    }
+
+    @ExperimentalTime
+    @Test
+    fun fetchWithTimeLimitNotExpired() {
+        var lock = CountDownLatch(1)
+
+        var value: String? = null
+        var error: Exception? = null
+        var source: Cache.Source? = null
+
+        expirableCache.get("not expired", { "world" }) { (v, e) ->
+            value = v
+            error = e
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("world"))
+        assertThat(error, nullValue())
+
+        value = null
+        error = null
+
+        Thread.sleep(1000)
+
+        lock = CountDownLatch(1)
+        expirableCache.get("not expired", { "new world" }, 5.seconds) { (v, e), type ->
+            value = v
+            error = e
+            source = type
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("world"))
+        assertThat(error, nullValue())
+        assertThat(source, not(equalTo(Cache.Source.ORIGIN)))
+    }
+
+    @ExperimentalTime
+    @Test
+    fun fetchWithTimeLimitNotExpiredButNotInMemory() {
+        var lock = CountDownLatch(1)
+
+        var value: String? = null
+        var error: Exception? = null
+        var source: Cache.Source? = null
+
+        expirableCache.get("not expired", { "world" }) { (v, e) ->
+            value = v
+            error = e
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("world"))
+        assertThat(error, nullValue())
+
+        value = null
+        error = null
+
+        Thread.sleep(1000)
+        expirableCache.remove("not expired", true)
+
+        lock = CountDownLatch(1)
+        expirableCache.get("not expired", { "new world" }, 5.seconds) { (v, e), type ->
+            value = v
+            error = e
+            source = type
+
+            lock.countDown()
+        }
+        lock.wait()
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("world"))
+        assertThat(error, nullValue())
+        assertThat(source, equalTo(Cache.Source.DISK))
+    }
+}

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseStringCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseStringCacheTest.kt
@@ -55,7 +55,7 @@ class FuseStringCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value, isEqualTo("world"))
         assertThat(error, nullValue())
-        assertThat(cacheSource, isEqualTo(Cache.Source.NOT_FOUND))
+        assertThat(cacheSource, isEqualTo(Cache.Source.ORIGIN))
     }
 
     @Test
@@ -117,7 +117,7 @@ class FuseStringCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value, containsString("<title>Google</title>"))
         assertThat(error, nullValue())
-        assertThat(cacheSource, isEqualTo(Cache.Source.NOT_FOUND))
+        assertThat(cacheSource, isEqualTo(Cache.Source.ORIGIN))
 
         // fetch again
         lock = CountDownLatch(1)


### PR DESCRIPTION
### What's in this PR?

This PR introduces the caching scenario that supports the expirable entry. 

### Description

The way it works is that whenever we fetch data with a timeLimit (Duration object specified). I will check with the entry timeStamp and calculate whether it is over the limit specified or not. 

If yes (Expired), it will re-fetch and save it back into Mem and Disk according.
If no (Not expired), it will quickly retrieve entry from the cache as normal.

By default, it will `get` the entry as if there was no limit (`Duration.INFINITY`), this means that Cache would never be expired in that sense.

Also, there is a Boolean flag indicates that the call-site is willing to get the cached data even if it is expired.

### API Surface

```kotlin
fun get(
  fetcher: Fetcher<T>,
  timeLimit: Duration = Duration.INFINITE,
  useEntryEvenIfExpired: Boolean = false,
  handler: ((Result<T, Exception>) -> Unit)? = null)

fun get(
  fetcher: Fetcher<T>,
  timeLimit: Duration = Duration.INFINITE,
  useEntryEvenIfExpired: Boolean = false,
  handler: ((Result<T, Exception>, Cache.Source) -> Unit)? = null
) 
```
