### PR TITLE
[API] Expose hasKey

### DIFF
--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
@@ -142,7 +142,8 @@ class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.
     }
 
     override fun hasKey(key: String): Boolean {
-        val value = memCache.get(key) ?: diskCache.get(key)
+        val safeKey = key.md5()
+        val value = memCache.get(safeKey) ?: diskCache.get(safeKey)
         return value != null
     }
 

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Cache.kt
@@ -65,7 +65,6 @@ class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.
     }
 
     private fun _get(fetcher: Fetcher<T>): Pair<Result<T, Exception>, Source> {
-
         val key = fetcher.key
         val safeKey = key.md5()
 
@@ -140,6 +139,11 @@ class Cache<T : Any> internal constructor(private val config: Config<T>) : Fuse.
     override fun allKeys(): Set<String> {
         val keys = memCache.allKeys()
         return keys.takeIf { it.isNotEmpty() } ?: diskCache.allKeys()
+    }
+
+    override fun hasKey(key: String): Boolean {
+        val value = memCache.get(key) ?: diskCache.get(key)
+        return value != null
     }
 
     override fun getTimestamp(key: String): Long {

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
@@ -69,6 +69,12 @@ class Fuse {
         fun allKeys(): Set<String>
 
         /**
+         *  Check whether the entry for the given key is there in the persistence or not
+         * @return Boolean The result of the check, true if the entry is there otherwise false
+         */
+        fun hasKey(key: String): Boolean
+
+        /**
          *  Retrieve the keys from all values persisted
          * @param key The key associated with the object to be persisted
          * @return Long represents the timestamp in milliseconds since epoch 1970

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/DiskCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/DiskCache.kt
@@ -34,7 +34,7 @@ internal class DiskCache private constructor(private val cache: DiskLruCache) : 
         }
     }
 
-    override fun remove(key: String) = cache.remove(key)
+    override fun remove(safeKey: String) = cache.remove(safeKey)
 
     override fun removeAll() {
         cache.delete()
@@ -50,10 +50,10 @@ internal class DiskCache private constructor(private val cache: DiskLruCache) : 
 
     override fun size(): Long = cache.size()
 
-    override fun get(key: String): ByteArray? = get(key, OutputStreamIndex.Data.ordinal)
+    override fun get(safeKey: String): ByteArray? = get(safeKey, OutputStreamIndex.Data.ordinal)
 
-    override fun getTimestamp(key: String): Long? =
-        get(key, OutputStreamIndex.Time.ordinal)?.toString(Charset.defaultCharset())?.toLong()
+    override fun getTimestamp(safeKey: String): Long? =
+        get(safeKey, OutputStreamIndex.Time.ordinal)?.toString(Charset.defaultCharset())?.toLong()
 
     private fun get(key: String, indexStream: Int): ByteArray? {
         val snapshot = cache.get(key)

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/MemCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/MemCache.kt
@@ -22,10 +22,10 @@ internal class MemCache : Persistence<Any> {
         }
     }
 
-    override fun remove(key: String): Boolean {
-        val removedValue = cache.remove(key)
-        cache.remove(convertKey(key, KEY_SUFFIX))
-        cache.remove(convertKey(key, TIME_SUFFIX))
+    override fun remove(safeKey: String): Boolean {
+        val removedValue = cache.remove(safeKey)
+        cache.remove(convertKey(safeKey, KEY_SUFFIX))
+        cache.remove(convertKey(safeKey, TIME_SUFFIX))
         return removedValue != null
     }
 
@@ -38,9 +38,9 @@ internal class MemCache : Persistence<Any> {
 
     override fun size(): Long = cache.size().toLong()
 
-    override fun get(key: String): Any? = cache.get(key)
+    override fun get(safeKey: String): Any? = cache.get(safeKey)
 
-    override fun getTimestamp(key: String): Long? = get(convertKey(key, TIME_SUFFIX)) as? Long
+    override fun getTimestamp(safeKey: String): Long? = get(convertKey(safeKey, TIME_SUFFIX)) as? Long
 
     private fun convertKey(key: String, suffix: String): String = "$key$suffix"
 }

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/Persistence.kt
@@ -12,12 +12,12 @@ internal interface Persistence<T> {
     fun put(safeKey: String, key: String, value: T, timeToPersist: Long)
 
     /**
-     * Remove the entry associated with its particular key
+     * Remove the entry associated with its particular safeKey
      *
-     * @param key The key associated with the object to be deleted from persistence
-     * @return Boolean Whether the key was removed successfully
+     * @param safeKey The safeKey associated with the object to be deleted from persistence
+     * @return Boolean Whether the safeKey was removed successfully
      */
-    fun remove(key: String): Boolean
+    fun remove(safeKey: String): Boolean
 
     /**
      * Remove all the entry in the persistence
@@ -37,16 +37,16 @@ internal interface Persistence<T> {
     fun size(): Long
 
     /**
-     * Get the value associated with its particular key
+     * Get the value associated with its particular safeKey
      *
-     * @param key The key associated with the value to be retrieved from persistence
+     * @param safeKey The safeKey associated with the value to be retrieved from persistence
      */
-    fun get(key: String): T?
+    fun get(safeKey: String): T?
 
     /**
-     * Get timestamp in milliseconds associated with its particular key
+     * Get timestamp in milliseconds associated with its particular safeKey
      *
-     * @param key The key associated with the value to be retrieved from persistence
+     * @param safeKey The safeKey associated with the value to be retrieved from persistence
      */
-    fun getTimestamp(key: String): Long?
+    fun getTimestamp(safeKey: String): Long?
 }

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -10,7 +10,6 @@ import com.github.kittinunf.fuse.core.getWithSource
 import com.github.kittinunf.fuse.core.put
 import java.nio.charset.Charset
 import java.util.concurrent.CountDownLatch
-import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.CoreMatchers.isA
@@ -51,9 +50,21 @@ class FuseByteCacheTest : BaseTestCase() {
         val (value, error) = result
 
         assertThat(value, notNullValue())
-        assertThat(value!!.toString(Charset.defaultCharset()), isEqualTo("world"))
+        assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, isEqualTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Cache.Source.ORIGIN))
+    }
+
+    @Test
+    fun hasKey() {
+        val (value, error) = cache.get("hello")
+
+        val hasKey = cache.hasKey("hello")
+
+        assertThat(value, notNullValue())
+        assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
+        assertThat(error, nullValue())
+        assertThat(hasKey, equalTo(true))
     }
 
     @Test
@@ -65,7 +76,7 @@ class FuseByteCacheTest : BaseTestCase() {
 
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
-        assertThat(source, isEqualTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Cache.Source.ORIGIN))
     }
 
     @Test
@@ -74,9 +85,9 @@ class FuseByteCacheTest : BaseTestCase() {
         val (value, error) = result
 
         assertThat(value, notNullValue())
-        assertThat(value!!.toString(Charset.defaultCharset()), isEqualTo("world"))
+        assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, isEqualTo(Cache.Source.MEM))
+        assertThat(source, equalTo(Cache.Source.MEM))
     }
 
     @Test
@@ -85,7 +96,7 @@ class FuseByteCacheTest : BaseTestCase() {
         val (value, error) = result
 
         assertThat(value, notNullValue())
-        assertThat(value!!.toString(Charset.defaultCharset()), isEqualTo("world"))
+        assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error, nullValue())
 
         // remove from memory cache
@@ -95,9 +106,9 @@ class FuseByteCacheTest : BaseTestCase() {
         val (value2, error2) = result2
 
         assertThat(value2, notNullValue())
-        assertThat(value2!!.toString(Charset.defaultCharset()), isEqualTo("world"))
+        assertThat(value2!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error2, nullValue())
-        assertThat(source2, isEqualTo(Cache.Source.DISK))
+        assertThat(source2, equalTo(Cache.Source.DISK))
     }
 
     @Test
@@ -157,7 +168,7 @@ class FuseByteCacheTest : BaseTestCase() {
 
         val timestamp = cache.getTimestamp("timestamp")
 
-        assertThat(timestamp, not(isEqualTo(-1L)))
+        assertThat(timestamp, not(equalTo(-1L)))
         assertThat(System.currentTimeMillis() - timestamp, greaterThan(2000L))
     }
 
@@ -201,6 +212,9 @@ class FuseByteCacheTest : BaseTestCase() {
 
         val anotherResult = cache.remove("remove", Cache.Source.MEM)
         assertThat(anotherResult, equalTo(true))
+
+        val hasKey = cache.hasKey("remove")
+        assertThat(hasKey, equalTo(false))
     }
 
     @Test

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseJsonCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseJsonCacheTest.kt
@@ -11,7 +11,6 @@ import com.github.kittinunf.fuse.core.put
 import java.io.FileNotFoundException
 import java.net.URL
 import java.nio.charset.Charset
-import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.isA
 import org.hamcrest.CoreMatchers.notNullValue
@@ -54,7 +53,7 @@ class FuseJsonCacheTest : BaseTestCase() {
         val (value, error) = cache.get(json)
 
         assertThat(value, notNullValue())
-        assertThat(value!!.getString("name"), isEqualTo("Product"))
+        assertThat(value!!.getString("name"), equalTo("Product"))
         assertThat(error, nullValue())
     }
 
@@ -65,7 +64,7 @@ class FuseJsonCacheTest : BaseTestCase() {
         val (value, error) = result
 
         assertThat(value, notNullValue())
-        assertThat(value!!.getString("url"), isEqualTo("https://www.httpbin.org/get"))
+        assertThat(value!!.getString("url"), equalTo("https://www.httpbin.org/get"))
         assertThat(error, nullValue())
         assertThat(source, equalTo(Cache.Source.ORIGIN))
 
@@ -73,7 +72,7 @@ class FuseJsonCacheTest : BaseTestCase() {
         val (anotherValue, anotherError) = anotherResult
 
         assertThat(anotherValue, notNullValue())
-        assertThat(anotherValue!!.getString("url"), isEqualTo("https://www.httpbin.org/get"))
+        assertThat(anotherValue!!.getString("url"), equalTo("https://www.httpbin.org/get"))
         assertThat(anotherError, nullValue())
         assertThat(anotherSource, equalTo(Cache.Source.MEM))
     }
@@ -112,7 +111,7 @@ class FuseJsonCacheTest : BaseTestCase() {
 
         assertThat(value, notNullValue())
         assertThat(error, nullValue())
-        assertThat(value!!.getString("name"), isEqualTo("New Product"))
+        assertThat(value!!.getString("name"), equalTo("New Product"))
     }
 
     @Test

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseStringCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseStringCacheTest.kt
@@ -6,7 +6,6 @@ import com.github.kittinunf.fuse.core.StringDataConvertible
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.get
 import com.github.kittinunf.fuse.core.getWithSource
-import org.hamcrest.CoreMatchers.`is` as isEqualTo
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
@@ -36,9 +35,9 @@ class FuseStringCacheTest : BaseTestCase() {
         val (value, error) = result
 
         assertThat(value, notNullValue())
-        assertThat(value, isEqualTo("world"))
+        assertThat(value, equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, isEqualTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Cache.Source.ORIGIN))
     }
 
     @Test
@@ -50,7 +49,7 @@ class FuseStringCacheTest : BaseTestCase() {
         val (value, error) = cache.get("hello", { "world" })
 
         assertThat(value, notNullValue())
-        assertThat(value, isEqualTo("WORLD1"))
+        assertThat(value, equalTo("WORLD1"))
         assertThat(error, nullValue())
     }
 
@@ -66,14 +65,14 @@ class FuseStringCacheTest : BaseTestCase() {
         val (value, error) = cache.get("hello", { "world" })
 
         assertThat(value, notNullValue())
-        assertThat(value, isEqualTo("world"))
+        assertThat(value, equalTo("world"))
         assertThat(error, nullValue())
 
         val (anotherResult, anotherSource) = cache.getWithSource("custom", { "world" })
         val (anotherValue, anotherError) = anotherResult
 
         assertThat(anotherValue, notNullValue())
-        assertThat(anotherValue, isEqualTo("WORLD"))
+        assertThat(anotherValue, equalTo("WORLD"))
         assertThat(anotherError, nullValue())
         assertThat(anotherSource, equalTo(Cache.Source.ORIGIN))
     }


### PR DESCRIPTION
### What's in this PR?

This PR exposes another API interface for us. This is to check whether the entry for the given `key` is there in the persistence layer or not.


### Implementation

It will check in the memcache first, then diskcache. If it couldn't be found in both then return false.

```kotlin
fun hasKey(key: String): Boolean
```