### PR TITLE
:arrow_down: decrease minSdkVersion to 15

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ subprojects {
             compileSdkVersion(28)
 
             defaultConfig {
-                minSdkVersion(21)
+                minSdkVersion(15)
                 targetSdkVersion(28)
 
                 versionCode = 1
@@ -135,7 +135,7 @@ subprojects {
             compileSdkVersion(29)
 
             defaultConfig {
-                minSdkVersion(21)
+                minSdkVersion(15)
                 targetSdkVersion(29)
 
                 versionCode = 1


### PR DESCRIPTION
Some apps may need a minSdkVersion < 21, and this is a blocking issue for mine. It seems to run just fine with minSdkVersion set to 15. 