### PR TITLE
:sparkles: Refactor Cache to be an interface

### DIFF
--- a/fuse-android/src/test/java/com/github/kittinunf/fuse/android/FuseByteCacheTest.kt
+++ b/fuse-android/src/test/java/com/github/kittinunf/fuse/android/FuseByteCacheTest.kt
@@ -1,8 +1,8 @@
 package com.github.kittinunf.fuse.android
 
 import com.github.kittinunf.fuse.core.ByteArrayDataConvertible
-import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.CacheBuilder
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.NotFoundException
 import com.github.kittinunf.fuse.core.get
@@ -52,7 +52,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
     }
 
     @Test
@@ -76,7 +76,7 @@ class FuseByteCacheTest : BaseTestCase() {
 
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
     }
 
     @Test
@@ -87,7 +87,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.MEM))
+        assertThat(source, equalTo(Source.MEM))
     }
 
     @Test
@@ -100,7 +100,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(error, nullValue())
 
         // remove from memory cache
-        cache.remove("hello", Cache.Source.MEM)
+        cache.remove("hello", Source.MEM)
 
         val (result2, source2) = cache.getWithSource("hello", { "world".toByteArray() })
         val (value2, error2) = result2
@@ -108,7 +108,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value2, notNullValue())
         assertThat(value2!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error2, nullValue())
-        assertThat(source2, equalTo(Cache.Source.DISK))
+        assertThat(source2, equalTo(Source.DISK))
     }
 
     @Test
@@ -180,10 +180,10 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), equalTo("yoyo"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
 
-        cache.remove("YOYO", Cache.Source.MEM)
-        cache.remove("YOYO", Cache.Source.DISK)
+        cache.remove("YOYO", Source.MEM)
+        cache.remove("YOYO", Source.DISK)
 
         val (anotherValue, anotherError) = cache.get("YOYO")
 
@@ -207,10 +207,10 @@ class FuseByteCacheTest : BaseTestCase() {
     fun removeFromDisk() {
         cache.put("remove", "test".toByteArray())
 
-        val result = cache.remove("remove", Cache.Source.DISK)
+        val result = cache.remove("remove", Source.DISK)
         assertThat(result, equalTo(true))
 
-        val anotherResult = cache.remove("remove", Cache.Source.MEM)
+        val anotherResult = cache.remove("remove", Source.MEM)
         assertThat(anotherResult, equalTo(true))
 
         val hasKey = cache.hasKey("remove")

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/Fuse.kt
@@ -44,7 +44,7 @@ class Fuse {
              * @param fetcher The fetcher object that can be used to fetch the new value from the origin
              * @return Pair<Result<T, Exception>, Cache.Source> The Pair of the result that represents the success/failure of the operation and The source of the entry
              */
-            fun getWithSource(fetcher: Fetcher<T>): Pair<Result<T, Exception>, Cache.Source>
+            fun getWithSource(fetcher: Fetcher<T>): Pair<Result<T, Exception>, Source>
         }
 
         /**
@@ -55,7 +55,7 @@ class Fuse {
          * @param fromSource The source of the value to be removed, either MEM or DISK
          * @return Boolean Whether the value was removed successfully
          */
-        fun remove(key: String, fromSource: Cache.Source = Cache.Source.MEM): Boolean
+        fun remove(key: String, fromSource: Source = Source.MEM): Boolean
 
         /**
          *  Remove all the entry in the persistence

--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/scenario/ExpirableCache.kt
@@ -2,6 +2,7 @@ package com.github.kittinunf.fuse.core.scenario
 
 import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.Fuse
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.fetch.Fetcher
 import com.github.kittinunf.fuse.core.fetch.NoFetcher
 import com.github.kittinunf.fuse.core.fetch.SimpleFetcher
@@ -52,13 +53,13 @@ class ExpirableCache<T : Any>(private val cache: Cache<T>) : Fuse.Cacheable by c
         fetcher: Fetcher<T>,
         timeLimit: Duration = Duration.INFINITE,
         useEntryEvenIfExpired: Boolean = false
-    ): Pair<Result<T, Exception>, Cache.Source> {
+    ): Pair<Result<T, Exception>, Source> {
         val key = fetcher.key
         val persistedTimestamp = getTimestamp(key)
 
         // no timestamp fetch, we need to just fetch the new data
         return if (persistedTimestamp == -1L) {
-            put(fetcher) to Cache.Source.ORIGIN
+            put(fetcher) to Source.ORIGIN
         } else {
             val isExpired = hasExpired(persistedTimestamp, timeLimit)
 
@@ -72,9 +73,9 @@ class ExpirableCache<T : Any>(private val cache: Cache<T>) : Fuse.Cacheable by c
         }
     }
 
-    private fun putOrGetFromCacheIfFailure(fetcher: Fetcher<T>): Pair<Result<T, Exception>, Cache.Source> {
+    private fun putOrGetFromCacheIfFailure(fetcher: Fetcher<T>): Pair<Result<T, Exception>, Source> {
         return when (val result = put(fetcher)) {
-            is Result.Success -> result to Cache.Source.ORIGIN
+            is Result.Success -> result to Source.ORIGIN
             is Result.Failure -> {
                 // fallback to cache
                 cache.getWithSource(fetcher)
@@ -108,7 +109,7 @@ fun <T : Any> ExpirableCache<T>.getWithSource(
     getValue: (() -> T?)? = null,
     timeLimit: Duration = Duration.INFINITE,
     useEntryEvenIfExpired: Boolean = false
-): Pair<Result<T, Exception>, Cache.Source> {
+): Pair<Result<T, Exception>, Source> {
     val fetcher = if (getValue == null) NoFetcher<T>(key) else SimpleFetcher(key, getValue)
     return getWithSource(fetcher, timeLimit, useEntryEvenIfExpired)
 }

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseByteCacheTest.kt
@@ -1,8 +1,8 @@
 package com.github.kittinunf.fuse
 
 import com.github.kittinunf.fuse.core.ByteArrayDataConvertible
-import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.CacheBuilder
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.NotFoundException
 import com.github.kittinunf.fuse.core.get
@@ -52,7 +52,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
     }
 
     @Test
@@ -76,7 +76,7 @@ class FuseByteCacheTest : BaseTestCase() {
 
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
     }
 
     @Test
@@ -87,7 +87,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.MEM))
+        assertThat(source, equalTo(Source.MEM))
     }
 
     @Test
@@ -100,7 +100,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(error, nullValue())
 
         // remove from memory cache
-        cache.remove("hello", Cache.Source.MEM)
+        cache.remove("hello", Source.MEM)
 
         val (result2, source2) = cache.getWithSource("hello", { "world".toByteArray() })
         val (value2, error2) = result2
@@ -108,7 +108,7 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value2, notNullValue())
         assertThat(value2!!.toString(Charset.defaultCharset()), equalTo("world"))
         assertThat(error2, nullValue())
-        assertThat(source2, equalTo(Cache.Source.DISK))
+        assertThat(source2, equalTo(Source.DISK))
     }
 
     @Test
@@ -180,10 +180,10 @@ class FuseByteCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.toString(Charset.defaultCharset()), equalTo("yoyo"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
 
-        cache.remove("YOYO", Cache.Source.MEM)
-        cache.remove("YOYO", Cache.Source.DISK)
+        cache.remove("YOYO", Source.MEM)
+        cache.remove("YOYO", Source.DISK)
 
         val (anotherValue, anotherError) = cache.get("YOYO")
 
@@ -207,10 +207,10 @@ class FuseByteCacheTest : BaseTestCase() {
     fun removeFromDisk() {
         cache.put("remove", "test".toByteArray())
 
-        val result = cache.remove("remove", Cache.Source.DISK)
+        val result = cache.remove("remove", Source.DISK)
         assertThat(result, equalTo(true))
 
-        val anotherResult = cache.remove("remove", Cache.Source.MEM)
+        val anotherResult = cache.remove("remove", Source.MEM)
         assertThat(anotherResult, equalTo(true))
 
         val hasKey = cache.hasKey("remove")

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseJsonCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseJsonCacheTest.kt
@@ -1,8 +1,8 @@
 package com.github.kittinunf.fuse
 
-import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.CacheBuilder
 import com.github.kittinunf.fuse.core.Fuse
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.DiskFetcher
 import com.github.kittinunf.fuse.core.get
@@ -66,7 +66,7 @@ class FuseJsonCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value!!.getString("url"), equalTo("https://www.httpbin.org/get"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
 
         val (anotherResult, anotherSource) = cache.getWithSource(httpBin)
         val (anotherValue, anotherError) = anotherResult
@@ -74,7 +74,7 @@ class FuseJsonCacheTest : BaseTestCase() {
         assertThat(anotherValue, notNullValue())
         assertThat(anotherValue!!.getString("url"), equalTo("https://www.httpbin.org/get"))
         assertThat(anotherError, nullValue())
-        assertThat(anotherSource, equalTo(Cache.Source.MEM))
+        assertThat(anotherSource, equalTo(Source.MEM))
     }
 
     @Test
@@ -96,7 +96,7 @@ class FuseJsonCacheTest : BaseTestCase() {
 
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
         assertThat(error as? JSONException, isA(JSONException::class.java))
     }
 

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
@@ -1,7 +1,7 @@
 package com.github.kittinunf.fuse
 
-import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.CacheBuilder
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.StringDataConvertible
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.Fetcher
@@ -45,15 +45,15 @@ class FuseScenarioTest : BaseTestCase() {
     @Test
     fun fetchWhenNoData() {
         // remove first if it exists
-        expirableCache.remove("hello", Cache.Source.MEM)
-        expirableCache.remove("hello", Cache.Source.DISK)
+        expirableCache.remove("hello", Source.MEM)
+        expirableCache.remove("hello", Source.DISK)
 
         val (result, source) = expirableCache.getWithSource("hello", { "world" })
         val (value, error) = result
 
         assertThat(value, notNullValue())
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
 
         val timestamp = expirableCache.getTimestamp("hello")
         assertThat(timestamp, not(equalTo(-1L)))
@@ -102,7 +102,7 @@ class FuseScenarioTest : BaseTestCase() {
         assertThat(anotherValue, notNullValue())
         assertThat(anotherValue, equalTo("new world"))
         assertThat(anotherError, nullValue())
-        assertThat(anotherSource, equalTo(Cache.Source.ORIGIN))
+        assertThat(anotherSource, equalTo(Source.ORIGIN))
     }
 
     @ExperimentalTime
@@ -127,7 +127,7 @@ class FuseScenarioTest : BaseTestCase() {
         assertThat(anotherValue, notNullValue())
         assertThat(anotherValue, equalTo("world"))
         assertThat(anotherError, nullValue())
-        assertThat(anotherSource, equalTo(Cache.Source.MEM))
+        assertThat(anotherSource, equalTo(Source.MEM))
     }
 
     @ExperimentalTime
@@ -147,7 +147,7 @@ class FuseScenarioTest : BaseTestCase() {
         assertThat(anotherValue, notNullValue())
         assertThat(anotherValue, equalTo("world"))
         assertThat(anotherError, nullValue())
-        assertThat(anotherSource, not(equalTo(Cache.Source.ORIGIN)))
+        assertThat(anotherSource, not(equalTo(Source.ORIGIN)))
     }
 
     @ExperimentalTime
@@ -160,7 +160,7 @@ class FuseScenarioTest : BaseTestCase() {
         assertThat(error, nullValue())
 
         Thread.sleep(1000)
-        expirableCache.remove("not expired", Cache.Source.MEM)
+        expirableCache.remove("not expired", Source.MEM)
 
         val (anotherResult, anotherSource) = expirableCache.getWithSource("not expired", { "new world" }, 5.seconds)
         val (anotherValue, anotherError) = anotherResult
@@ -168,7 +168,7 @@ class FuseScenarioTest : BaseTestCase() {
         assertThat(anotherValue, notNullValue())
         assertThat(anotherValue, equalTo("world"))
         assertThat(anotherError, nullValue())
-        assertThat(anotherSource, equalTo(Cache.Source.DISK))
+        assertThat(anotherSource, equalTo(Source.DISK))
     }
 
     @ExperimentalTime
@@ -206,7 +206,7 @@ class FuseScenarioTest : BaseTestCase() {
 
         assertThat(anotherValue, notNullValue())
         assertThat(anotherError, nullValue())
-        assertThat(anotherSource, not(equalTo(Cache.Source.ORIGIN)))
+        assertThat(anotherSource, not(equalTo(Source.ORIGIN)))
     }
 
     @ExperimentalTime
@@ -218,8 +218,8 @@ class FuseScenarioTest : BaseTestCase() {
         assertThat(value, equalTo("foofoo2"))
         assertThat(error, nullValue())
 
-        expirableCache.remove("foofoo", Cache.Source.MEM)
-        expirableCache.remove("foofoo", Cache.Source.DISK)
+        expirableCache.remove("foofoo", Source.MEM)
+        expirableCache.remove("foofoo", Source.DISK)
 
         val goodFetcher = object : Fetcher<String> {
             override val key: String = "foofoo"
@@ -247,6 +247,6 @@ class FuseScenarioTest : BaseTestCase() {
 
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
     }
 }

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseStringCacheTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseStringCacheTest.kt
@@ -1,7 +1,7 @@
 package com.github.kittinunf.fuse
 
-import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.CacheBuilder
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.StringDataConvertible
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.get
@@ -37,7 +37,7 @@ class FuseStringCacheTest : BaseTestCase() {
         assertThat(value, notNullValue())
         assertThat(value, equalTo("world"))
         assertThat(error, nullValue())
-        assertThat(source, equalTo(Cache.Source.ORIGIN))
+        assertThat(source, equalTo(Source.ORIGIN))
     }
 
     @Test
@@ -74,6 +74,6 @@ class FuseStringCacheTest : BaseTestCase() {
         assertThat(anotherValue, notNullValue())
         assertThat(anotherValue, equalTo("WORLD"))
         assertThat(anotherError, nullValue())
-        assertThat(anotherSource, equalTo(Cache.Source.ORIGIN))
+        assertThat(anotherSource, equalTo(Source.ORIGIN))
     }
 }

--- a/fuse/src/test/java/com/github/kittinunf/fuse/NetworkFetcher.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/NetworkFetcher.kt
@@ -2,6 +2,7 @@ package com.github.kittinunf.fuse
 
 import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.Fuse
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.fetch.Fetcher
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
@@ -55,5 +56,5 @@ class NetworkFetcher<T : Any>(
 
 fun <T : Any> Cache<T>.get(url: URL): Result<T, Exception> = get(NetworkFetcher(url, this))
 
-fun <T : Any> Cache<T>.getWithSource(url: URL): Pair<Result<T, Exception>, Cache.Source> =
+fun <T : Any> Cache<T>.getWithSource(url: URL): Pair<Result<T, Exception>, Source> =
     getWithSource(NetworkFetcher(url, this))

--- a/sample/src/main/java/com/github/kittinunf/fuse/sample/LocalTimeRepository.kt
+++ b/sample/src/main/java/com/github/kittinunf/fuse/sample/LocalTimeRepository.kt
@@ -2,8 +2,8 @@ package com.github.kittinunf.fuse.sample
 
 import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuse.android.defaultAndroidMemoryCache
-import com.github.kittinunf.fuse.core.Cache
 import com.github.kittinunf.fuse.core.CacheBuilder
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.fuse.core.StringDataConvertible
 import com.github.kittinunf.fuse.core.build
 import com.github.kittinunf.fuse.core.fetch.Fetcher
@@ -20,7 +20,7 @@ interface LocalTimeRepository {
 
 interface CacheableLocalTimeRepository : LocalTimeRepository {
 
-    fun getLocalTimeIfNotExpired(place: String): Pair<Result<LocalTime, Exception>, Cache.Source>
+    fun getLocalTimeIfNotExpired(place: String): Pair<Result<LocalTime, Exception>, Source>
 }
 
 private val fuel = FuelManager().apply {
@@ -51,7 +51,7 @@ class CacheRepository(dir: String) : CacheableLocalTimeRepository {
     }
 
     @ExperimentalTime
-    override fun getLocalTimeIfNotExpired(place: String): Pair<Result<LocalTime, Exception>, Cache.Source> {
+    override fun getLocalTimeIfNotExpired(place: String): Pair<Result<LocalTime, Exception>, Source> {
         val area = place.continent
         val location = place.area
 

--- a/sample/src/main/java/com/github/kittinunf/fuse/sample/LocalTimeService.kt
+++ b/sample/src/main/java/com/github/kittinunf/fuse/sample/LocalTimeService.kt
@@ -1,6 +1,6 @@
 package com.github.kittinunf.fuse.sample
 
-import com.github.kittinunf.fuse.core.Cache
+import com.github.kittinunf.fuse.core.Source
 import com.github.kittinunf.result.Result
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
@@ -15,7 +15,7 @@ interface LocalTimeService {
     fun getFromBoth(location: String, handler: (Result<LocalTime, Exception>) -> Unit)
 
     // get from cache if available within 5 minutes otherwise refresh from network
-    fun getFromCacheIfNotExpired(location: String, handler: (Result<LocalTime, Exception>, Cache.Source) -> Unit)
+    fun getFromCacheIfNotExpired(location: String, handler: (Result<LocalTime, Exception>, Source) -> Unit)
 }
 
 class LocalTimeServiceImpl(private val network: LocalTimeRepository, private val cache: CacheableLocalTimeRepository) :
@@ -63,7 +63,7 @@ class LocalTimeServiceImpl(private val network: LocalTimeRepository, private val
 
     override fun getFromCacheIfNotExpired(
         location: String,
-        handler: (Result<LocalTime, Exception>, Cache.Source) -> Unit
+        handler: (Result<LocalTime, Exception>, Source) -> Unit
     ) {
         dispatchDefault {
             val (result, source) = cache.getLocalTimeIfNotExpired(location)


### PR DESCRIPTION
…tions

In reference to this issue: https://github.com/kittinunf/Fuse/issues/40

### What is the problem you are trying to solve?

Per issue #40, reading from the cache is not as fast as it _could be_ in certain scenarios. There is logic that both reads from, and writes to, the disk cache **even when the cached data is readily available from memory.** This drastically slows down what should otherwise be a fast fetch of data. 

The reason for the disk read and write in this scenario ^ makes sense. You are making sure the disk LRU is updated to reflect the recent access to a cached entry.

I think, ideally, such updates would be non-blocking (performed asynchronously). I actually started down this path. The contract requirement to return a `Result`, however, halted my progress. If a caller issues a cache `put` expecting a `Result`, the only two options are `Result.Success` or `Result.Failure`. How could a `Result` be returned immediately, if the disk cache update is happening asynchronously? It can't. You would instead, perhaps, need a `Result.Pending` or something along those lines.

I felt your current implementation had contract obligations that I wasn't ready to upset. After all, you may already have clients that actually _depend_ on the disk updates being synchronous. I would love to discuss this further, if you are open to contractual changes that might incorporate asynchronous disk cache updates **as standard.**

Instead, my strategy for this PR was to simply make it possible to have an alternate implementation of the `Cache` class. This would allow myself, or others, to create their own implementation that chooses a different disk write strategy. 

### What changed specifically?

1. Your concrete `Cache` class was renamed to `CacheImpl`.
2. A `Cache` interface was introduced, and `CacheImpl` changed to implement that.
3. The `Source` enum was moved to be a top-level construct for other classes (such as my own implementation [yet to be written]) to use.
4. References to `CacheImpl.Source` were changed to just be `Source`.
5. I made one additional optimization, which I will call out in the code below.

### Anything else?

I confirmed that your tests all still pass. I also made sure the sample app was still working. 