### PR TITLE
:bug: Fix nullable keys

### DIFF
--- a/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/DiskCache.kt
+++ b/fuse/src/main/java/com/github/kittinunf/fuse/core/cache/DiskCache.kt
@@ -42,7 +42,7 @@ internal class DiskCache private constructor(private val cache: DiskLruCache) : 
         .toSet()
 
     private fun allSafeKeys() = synchronized(this) {
-        cache.directory.listFiles().filter { it.isFile && it.name != JOURNAL_FILE }.map { it.name.substringBefore(".") }
+        cache.directory.listFiles()?.filter { it.isFile && it.name != JOURNAL_FILE }?.map { it.name.substringBefore(".") } ?: emptyList()
     }
 
     override fun size(): Long = cache.size()

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
@@ -21,6 +21,7 @@ import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
+import java.io.File
 
 class FuseScenarioTest : BaseTestCase() {
 
@@ -248,5 +249,25 @@ class FuseScenarioTest : BaseTestCase() {
         assertThat(value, nullValue())
         assertThat(error, notNullValue())
         assertThat(source, equalTo(Source.ORIGIN))
+    }
+
+    @ExperimentalTime
+    @Test
+    fun cleanEmptyCacheWillNotCrash() {
+        val (value, error) = expirableCache.put("foofoo", "foofoo2")
+
+        assertThat(value, notNullValue())
+        assertThat(value, equalTo("foofoo2"))
+        assertThat(error, nullValue())
+
+        val cacheDir = File(tempDir)
+        assert(cacheDir.exists())
+
+        cacheDir.deleteRecursively()
+        assert(!cacheDir.exists())
+
+        expirableCache.removeAll()
+
+        assert(expirableCache.allKeys().isEmpty())
     }
 }

--- a/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
+++ b/fuse/src/test/java/com/github/kittinunf/fuse/FuseScenarioTest.kt
@@ -10,6 +10,7 @@ import com.github.kittinunf.fuse.core.scenario.get
 import com.github.kittinunf.fuse.core.scenario.getWithSource
 import com.github.kittinunf.fuse.core.scenario.put
 import com.github.kittinunf.result.Result
+import java.io.File
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
@@ -21,7 +22,6 @@ import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 
 class FuseScenarioTest : BaseTestCase() {
 


### PR DESCRIPTION
# Description
In case we try to clear the cache before we add anything there, we will get an IllegalStateException as calling `cache.directory.listFiles()` returns null.

## Solution
If `listFiles()` object is null we will return an `emptyList()`.

## Stacktrace

```
Caused by java.lang.IllegalStateException: cache.directory.listFiles() must not be null
       at com.github.kittinunf.fuse.core.cache.DiskCache.allSafeKeys(DiskCache.java:2)
       at com.github.kittinunf.fuse.core.cache.DiskCache.get(DiskCache.java)
       at com.github.kittinunf.fuse.core.Cache.removeAll(Cache.java:2)
       at com.github.kittinunf.fuse.core.scenario.ExpirableCache.removeAll(ExpirableCache.java:2)
```